### PR TITLE
BU-3740 Flag when json recovered from truncated

### DIFF
--- a/lib/rjson/handler.rb
+++ b/lib/rjson/handler.rb
@@ -38,8 +38,6 @@ module RJSON
           output["_truncated"] = true 
         elsif output.is_a? Array
           output.push "_truncated"
-        else
-          throw "JSON doc is a single, truncated scalar"
         end
       end
       output

--- a/lib/rjson/handler.rb
+++ b/lib/rjson/handler.rb
@@ -1,9 +1,11 @@
 module RJSON
   class Handler
     attr_reader :stack
+    attr_accessor :truncated
 
     def initialize
       @stack = [[:root]]
+      @truncated = false
     end
 
     def start_object
@@ -31,7 +33,16 @@ module RJSON
     def result
       root = @stack.first.last
       output = process root.first, root.drop(1)
-      output[:_truncated] = true if @truncated
+      if @truncated
+        if output.is_a? Hash
+          output["_truncated"] = true 
+        elsif output.is_a? Array
+          output.push "_truncated"
+        else
+          throw "JSON doc is a single, truncated scalar"
+        end
+      end
+      output
     end
 
     def process type, rest

--- a/lib/rjson/handler.rb
+++ b/lib/rjson/handler.rb
@@ -59,6 +59,9 @@ module RJSON
     # Recover an invalid parse tree by dropping items that we're not certain are
     # fully recoverable
     def recover!
+      # The `_truncated` flag is currently added to _all_ JSON docs that
+      # have parsing errors, whatever the cause.
+      # TODO: Only add this flag when parse-errors are caused by truncation
       @truncated = true
 
       current_context = stack.last

--- a/lib/rjson/handler.rb
+++ b/lib/rjson/handler.rb
@@ -30,7 +30,8 @@ module RJSON
 
     def result
       root = @stack.first.last
-      process root.first, root.drop(1)
+      output = process root.first, root.drop(1)
+      output[:_truncated] = true if @truncated
     end
 
     def process type, rest
@@ -49,6 +50,8 @@ module RJSON
     # Recover an invalid parse tree by dropping items that we're not certain are
     # fully recoverable
     def recover!
+      @truncated = true
+
       current_context = stack.last
       _type, *rest = current_context
 

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -13,22 +13,22 @@ module RJSON
     end
 
     def test_truncated_array
-      assert_parses_as('["foo"]',
+      assert_parses_as('["foo","_truncated"]',
                        '["foo",nul')
     end
 
     def test_truncated_number_in_array
-      assert_parses_as('["foo"]',
+      assert_parses_as('["foo","_truncated"]',
                        '["foo",1')
     end
 
     def test_truncated_array_ends_with_comma
-      assert_parses_as('["foo"]',
+      assert_parses_as('["foo","_truncated"]',
                        '["foo",')
     end
 
     def test_truncated_array_ends_with_opening_square_bracket
-      assert_parses_as('["foo",[]]',
+      assert_parses_as('["foo",[],"_truncated"]',
                        '["foo",[')
     end
 
@@ -38,7 +38,7 @@ module RJSON
     end
 
     def test_truncated_value_in_nested_array
-      assert_parses_as('["foo",[10.3,["bar"]]]',
+      assert_parses_as('["foo",[10.3,["bar"]],"_truncated"]',
                        '["foo",[10.3,["bar",fals')
     end
 
@@ -48,17 +48,17 @@ module RJSON
     end
 
     def test_truncated_object
-      assert_parses_as('{"foo":true}',
+      assert_parses_as('{"foo":true,"_truncated":true}',
                        '{"foo":true,"bar":fals')
     end
 
     def test_truncated_first_value_in_object
-      assert_parses_as('{}',
+      assert_parses_as('{"_truncated":true}',
                        '{"foo":tru')
     end
 
     def test_truncated_number_in_object
-      assert_parses_as('{"foo":13.5}',
+      assert_parses_as('{"foo":13.5,"_truncated":true}',
                        '{"foo":13.5,"bar":1')
     end
 
@@ -68,37 +68,37 @@ module RJSON
     end
 
     def test_truncated_value_in_nested_object
-      assert_parses_as('{"foo":13.5,"bar":{}}',
+      assert_parses_as('{"foo":13.5,"bar":{},"_truncated":true}',
                        '{"foo":13.5,"bar":{"baz":fals')
     end
 
     def test_truncated_object_key
-      assert_parses_as('{"foo":true}',
+      assert_parses_as('{"foo":true,"_truncated":true}',
                        '{"foo":true,"ba')
     end
 
     def test_truncated_object_ends_with_complete_key
-      assert_parses_as('{"foo":true}',
+      assert_parses_as('{"foo":true,"_truncated":true}',
                        '{"foo":true,"bar"')
     end
 
     def test_truncated_object_ends_with_colon
-      assert_parses_as('{"foo":true}',
+      assert_parses_as('{"foo":true,"_truncated":true}',
                        '{"foo":true,"bar":')
     end
 
     def test_truncated_object_ends_with_comma
-      assert_parses_as('{"foo":true}',
+      assert_parses_as('{"foo":true,"_truncated":true}',
                        '{"foo":true,')
     end
 
     def test_truncated_object_ends_with_opening_curly
-      assert_parses_as('{"foo":{}}',
+      assert_parses_as('{"foo":{},"_truncated":true}',
                        '{"foo":{')
     end
 
     def test_truncated_object_ends_with_decimal_point
-      assert_parses_as('{"foo":true}',
+      assert_parses_as('{"foo":true,"_truncated":true}',
                        '{"foo":true,"foo_fraction":0.')
     end
 


### PR DESCRIPTION
### ~~Review after #2~~

- Sub-task/issue: https://bridgeu.atlassian.net/browse/BU-3740
- Scope document: https://paper.dropbox.com/doc/BU-3585-Rebuild-Mixpanel-Data-Zs1uFDF87kH1Zv3P7kBjt

---

This pull request adds a key value pair `_truncated: true` to any JSON Hashes (or the string `"_truncated"` to any Arrays) that were truncated and `recover!`ed from. 